### PR TITLE
Path::Tiny object does not act as string

### DIFF
--- a/lib/Dist/Inkt.pm
+++ b/lib/Dist/Inkt.pm
@@ -296,7 +296,7 @@ sub BuildTarball
 	{
 		my $abs = path($_);
 		$tar->add_files($abs);
-		$tar->rename(substr($abs, 1), "$pfx/".$abs->relative($root));
+		$tar->rename(substr($abs->stringify, 1), "$pfx/".$abs->relative($root));
 	}
 	
 	$tar->write($file, Archive::Tar::COMPRESS_GZIP());


### PR DESCRIPTION
There is no overload for Path::Tiny for string. Should use stringify function https://metacpan.org/pod/release/DAGOLDEN/Path-Tiny-0.072/lib/Path/Tiny.pm#stringify to get back a string as opposed to the object.
